### PR TITLE
Renamed identifiers inconsistencies

### DIFF
--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/awo/utils/AwoDependency.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/awo/utils/AwoDependency.java
@@ -321,10 +321,10 @@ public class AwoDependency {
                 boolean exclude = false;
                 for (DependencyResult resolvedDependencyResult2 : providedDependencySet) {
                     if (resolvedDependencyResult2 instanceof ResolvedDependencyResult) {
-                        ModuleVersionIdentifier moduleVersion2 = ((ResolvedDependencyResult) resolvedDependencyResult2)
+                        ModuleVersionIdentifier id = ((ResolvedDependencyResult) resolvedDependencyResult2)
                                 .getSelected()
                                 .getModuleVersion();
-                        String key2 = moduleVersion2.getGroup() + "-" + moduleVersion2.getName();
+                        String key2 = id.getGroup() + "-" + id.getName();
                         if (key.equals(key2)) {
                             exclude = true;
                             break;

--- a/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/dx/dex/code/form/Form12x.java
+++ b/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/dx/dex/code/form/Form12x.java
@@ -126,9 +126,9 @@ public final class Form12x extends InsnFormat {
                 bits.set(0, false);
                 bits.set(1, false);
             } else {
-                boolean dstRegComp = unsignedFitsInNibble(r1);
-                bits.set(0, dstRegComp);
-                bits.set(1, dstRegComp);
+                boolean compat = unsignedFitsInNibble(r1);
+                bits.set(0, compat);
+                bits.set(1, compat);
             }
 
             bits.set(2, unsignedFitsInNibble(regs.get(2).getReg()));

--- a/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/dx/dex/file/DexFile.java
+++ b/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/dx/dex/file/DexFile.java
@@ -568,14 +568,14 @@ public final class DexFile {
                 out.writeZeroes(one.getFileOffset() - out.getCursor());
                 one.writeTo(out);
             } catch (RuntimeException ex) {
-                ExceptionWithContext ec;
+                ExceptionWithContext ewc;
                 if (ex instanceof ExceptionWithContext) {
-                    ec = (ExceptionWithContext) ex;
+                    ewc = (ExceptionWithContext) ex;
                 } else {
-                    ec = new ExceptionWithContext(ex);
+                    ewc = new ExceptionWithContext(ex);
                 }
-                ec.addContext("...while writing section " + i);
-                throw ec;
+                ewc.addContext("...while writing section " + i);
+                throw ewc;
             }
         }
 

--- a/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/dx/ssa/SsaMethod.java
+++ b/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/dx/ssa/SsaMethod.java
@@ -90,17 +90,17 @@ public final class SsaMethod {
     private boolean backMode;
 
     /**
-     * @param ropMethod rop-form method to convert from
+     * @param rmeth rop-form method to convert from
      * @param paramWidth the total width, in register-units, of the
      * method's parameters
      * @param isStatic {@code true} if this method has no {@code this}
      * pointer argument
      */
-    public static SsaMethod newFromRopMethod(RopMethod ropMethod,
+    public static SsaMethod newFromRopMethod(RopMethod rmeth,
             int paramWidth, boolean isStatic) {
-        SsaMethod result = new SsaMethod(ropMethod, paramWidth, isStatic);
+        SsaMethod result = new SsaMethod(rmeth, paramWidth, isStatic);
 
-        result.convertRopToSsaBlocks(ropMethod);
+        result.convertRopToSsaBlocks(rmeth);
 
         return result;
     }

--- a/atlas-update/src/main/java/com/taobao/common/dexpatcher/algorithms/diff/utils/SmallDexPatchGenerator.java
+++ b/atlas-update/src/main/java/com/taobao/common/dexpatcher/algorithms/diff/utils/SmallDexPatchGenerator.java
@@ -526,12 +526,12 @@ public final class SmallDexPatchGenerator {
             patchedDexToSmallPatchedMapListOffsetMap.put(
                     patchedDex, smallPatchedMapListOffset
             );
-            int smallPatchedMapListSize
+            int position
                     = SizeOf.UINT + SizeOf.MAP_ITEM * smallPatchedSectionCount;
 
             int smallPatchedDexSize
                     = smallPatchedMapListOffset
-                    + smallPatchedMapListSize;
+                    + position;
             patchedDexToSmallPatchedDexSizeMap.put(patchedDex, smallPatchedDexSize);
         }
     }


### PR DESCRIPTION
I used an automatic tool which suggests useful renaming operations based on the frequency such names appear in the code-base. For example, "ewc" appears more frequently than "ec" in the context in which "ec" is used, so I renamed it. I did not modify functional parts of the code, I just applied such renamings.