### PR TITLE
bundle find rules: add a getApplicationInfo().nativeLibraryDir in bun…

### DIFF
--- a/atlas-core/src/main/java/android/taobao/atlas/framework/BundleInstaller.java
+++ b/atlas-core/src/main/java/android/taobao/atlas/framework/BundleInstaller.java
@@ -614,6 +614,11 @@ public class BundleInstaller implements Callable{
 
     /**
      * 获取bundle源文件地址
+     *
+     * bundle finding order by follwing paths:
+     * 1) ${getApplicationInfo().dataDir}/lib/
+     * 2) ${getApplicationInfo().nativeLibraryDir}
+     * 3) apk's "lib/armeabi" path.
      * @param location
      */
     private void findBundleSource(String location) throws IOException{
@@ -623,6 +628,11 @@ public class BundleInstaller implements Callable{
         String bundleFileName = String.format("lib%s.so",location.replace(".","_"));
         String bundlePath = String.format("%s/lib/%s", dataDir,bundleFileName);
         File bundleFile = new File(bundlePath);
+
+
+        if(!bundleFile.exists()){
+            bundleFile = new File(RuntimeVariables.androidApplication.getApplicationInfo().nativeLibraryDir,bundleFileName);
+        }
         if(bundleFile.exists() && AtlasBundleInfoManager.instance().isInternalBundle(location)){
             mTmpBundleSourceFile = bundleFile;
         }else{


### PR DESCRIPTION

getApplicationInfo().nativeLibraryDir is added into bundle finding rules because some pre-build app will extract lib to this path.
add this support to support build in app with shared lib extraction.