### PR TITLE
use gradle ext to keep support lib version

### DIFF
--- a/atlas-demo/AtlasDemo/activitygroupcompat/build.gradle
+++ b/atlas-demo/AtlasDemo/activitygroupcompat/build.gradle
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
     compile('com.taobao.android:atlas_core:5.0.6-rc9@aar')
 }

--- a/atlas-demo/AtlasDemo/build.gradle
+++ b/atlas-demo/AtlasDemo/build.gradle
@@ -28,3 +28,7 @@ subprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+ext {
+    baseSupportVersion = "25.2.0"
+}

--- a/atlas-demo/AtlasDemo/firstbundle/build.gradle
+++ b/atlas-demo/AtlasDemo/firstbundle/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     providedCompile project(':middlewarelibrary')
 //    bundleCompile project(':publicbundle')
 
-    providedCompile 'com.android.support:support-v4:25.3.0'
-    providedCompile 'com.android.support:appcompat-v7:25.1.0'
+    providedCompile 'com.android.support:support-v4:' + rootProject.ext.baseSupportVersion
+    providedCompile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
     providedCompile 'com.android.support.constraint:constraint-layout:1.0.0-alpha8'
 }

--- a/atlas-demo/AtlasDemo/lottie/build.gradle
+++ b/atlas-demo/AtlasDemo/lottie/build.gradle
@@ -20,5 +20,5 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:appcompat-v7:25.2.0'
+  compile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
 }

--- a/atlas-demo/AtlasDemo/middlewarelibrary/build.gradle
+++ b/atlas-demo/AtlasDemo/middlewarelibrary/build.gradle
@@ -21,8 +21,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.3.0'
-    compile 'com.android.support:design:25.3.0'
+    compile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
+    compile 'com.android.support:support-v4:' + rootProject.ext.baseSupportVersion
+    compile 'com.android.support:recyclerview-v7:' + rootProject.ext.baseSupportVersion
+    compile 'com.android.support:design:' + rootProject.ext.baseSupportVersion
 }

--- a/atlas-demo/AtlasDemo/publicbundle/build.gradle
+++ b/atlas-demo/AtlasDemo/publicbundle/build.gradle
@@ -33,5 +33,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
 }

--- a/atlas-demo/AtlasDemo/secondbundle/build.gradle
+++ b/atlas-demo/AtlasDemo/secondbundle/build.gradle
@@ -36,8 +36,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(":secondbundlelibrary");
-    providedCompile 'com.android.support:appcompat-v7:25.1.0'
-    providedCompile 'com.android.support:support-v4:25.3.0'
+    providedCompile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
+    providedCompile 'com.android.support:support-v4:' + rootProject.ext.baseSupportVersion
     providedCompile 'com.android.support.constraint:constraint-layout:1.0.0-alpha8'
     providedCompile project(':middlewarelibrary')
 

--- a/atlas-demo/AtlasDemo/secondbundlelibrary/build.gradle
+++ b/atlas-demo/AtlasDemo/secondbundlelibrary/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.0'
+    compile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
     compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha8'
     testCompile 'junit:junit:4.12'
 }

--- a/atlas-demo/AtlasDemo/splashscreen/build.gradle
+++ b/atlas-demo/AtlasDemo/splashscreen/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:' + rootProject.ext.baseSupportVersion
     compile project(':middlewarelibrary')
     compile project(':lottie')
 


### PR DESCRIPTION
it's easy to change ALL support lib version at one time correctly.
more see:
http://tools.android.com/tech-docs/new-build-system/tips