### PR TITLE
bundle patcher: fix exception when looper prepare twice.

### DIFF
--- a/atlas-core/src/main/java/android/taobao/atlas/startup/patch/releaser/BundleReleaser.java
+++ b/atlas-core/src/main/java/android/taobao/atlas/startup/patch/releaser/BundleReleaser.java
@@ -261,7 +261,8 @@ public class BundleReleaser {
         this.hasReleased = hasReleased;
         this.reversionDir = reversionDir;
         if (!(Looper.getMainLooper() == Looper.myLooper())) {
-            Looper.prepare();
+            if (Looper.myLooper() != null)
+                Looper.prepare();
         }
         handler = new Handler(new Handler.Callback() {
             @Override


### PR DESCRIPTION
When init updater in a handler thread, it will throw exception.

"java.lang.RuntimeException: Only one Looper may be created per thread"

so only prepare this when looper is not prepared.