### PR TITLE
修复mtl.fastProguard=false时，只读取consumerProguard中keep规则的逻辑

### DIFF
--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/transform/AtlasProguardTransform.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/transform/AtlasProguardTransform.java
@@ -270,6 +270,7 @@ public class AtlasProguardTransform extends ProGuardTransform {
     static boolean firstTime = true;
 
     List<File> defaultProguardFiles = new ArrayList<>();
+    private List<File> nonConsumerProguardFiles = new ArrayList<>();
 
     @Override
     public Set<ContentType> getOutputTypes() {
@@ -305,6 +306,8 @@ public class AtlasProguardTransform extends ProGuardTransform {
                     appVariantContext.getVariantData().getVariantConfiguration().getBuildType().getProguardFiles());
         }else {
                     defaultProguardFiles.addAll(oldConfigurableFileCollection.getFiles());
+            nonConsumerProguardFiles.addAll(
+                appVariantContext.getVariantData().getVariantConfiguration().getBuildType().getProguardFiles());
 
         }
         List<AwbBundle> awbBundles = AtlasBuildContext.androidDependencyTrees.get(
@@ -504,7 +507,7 @@ public class AtlasProguardTransform extends ProGuardTransform {
     @Override
     public void applyConfigurationFile(File file) throws IOException, ParseException {
         //appVariantContext.getVariantConfiguration().getProguardFiles(false, new ArrayList<>());
-        if (!defaultProguardFiles.contains(file) && buildConfig.isLibraryProguardKeepOnly()) {
+        if (buildConfig.isLibraryProguardKeepOnly() && !nonConsumerProguardFiles.contains(file)) {
             appVariantContext.getProject().getLogger().info("applyConfigurationFile keep only :" + file);
             applyLibConfigurationFile(file);
             return;


### PR DESCRIPTION
fastProguard=false时，原有逻辑还会去解析consumerProguard中的非keep规则，会导致很多问题。

目前发现的case时，consumerProguard中，包含了-printConfiguration xxx 规则，覆盖了之前设置好的configuration print 路径，导致后续的Proguard处理过程由于找不到 configuration print的路径，发生构建Exception。