### PR TITLE
[atlas-gradle-plugin] fix #291 宿主修改layout资源后，动态部署没生效

### DIFF
--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/tpatch/TPatchDiffResAPBuildTask.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/tpatch/TPatchDiffResAPBuildTask.java
@@ -562,7 +562,7 @@ public class TPatchDiffResAPBuildTask extends BaseTask {
                     if (null != newFiles) {
                         for (Map.Entry<String, String> entry : newFiles.entrySet()) {
                             String name = entry.getKey();
-                            if (name.startsWith("res/")) {
+                            if (name.replace("\\", "/").startsWith("res/")) {
                                 String md5 = entry.getValue();
                                 String baseMd5 = baseFiles.get(name);
                                 if (null == baseMd5 || !baseMd5.equals(md5)) {

--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tools/diff/DiffResExtractor.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tools/diff/DiffResExtractor.java
@@ -277,7 +277,7 @@ public class DiffResExtractor {
 
             String relativePath = file.getAbsolutePath().substring(basePathLength);
 
-            if (!relativePath.startsWith("/assets/")) {
+            if (!relativePath.replace("\\", "/").startsWith("/assets/")) {
                 continue;
             }
 


### PR DESCRIPTION
修复windows开发环境下，宿主的res与assets修改后，打差异包没生效问题