### PR TITLE
3.0.1 rc88 fix sign npe

### DIFF
--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tools/sign/LocalSignHelper.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tools/sign/LocalSignHelper.java
@@ -281,8 +281,11 @@ public class LocalSignHelper {
                     if (certificateInfo == null) {
                         throw new SigningException("Failed to read key from keystore");
                     }
+                    System.err.println("LocalSign:"+signingConfig.toString());
+                } else {
+                    throw new SigningException("SigningConfig not found or incomplete");
                 }
-                System.err.println("LocalSign:"+signingConfig.toString());
+
 
                 Predicate<String> noCompressPredicate = getNoCompressPredicate(inputFile.getAbsolutePath());
                         ApkCreatorFactory.CreationData creationData =


### PR DESCRIPTION
当签名未配置或配置不完整的情况下，signingConfig.toString()会报非空指针异常，改为提示"SigningConfig not found or incomplete"。