### PR TITLE
fix process java resource issue

### DIFF
--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/transform/AtlasMergeJavaResourcesTransform.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/transform/AtlasMergeJavaResourcesTransform.java
@@ -146,8 +146,12 @@ public class AtlasMergeJavaResourcesTransform extends MergeJavaResourcesTransfor
     @Override
     public void transform(TransformInvocation invocation) throws IOException {
         // only custom process native lib
-        if (mergedType == QualifiedContent.DefaultContentType.RESOURCES) {
-            super.transform(invocation);
+        if (mergedType.contains(QualifiedContent.DefaultContentType.RESOURCES)) {
+            try {
+                super.transform(invocation);
+            } catch (Exception e) {
+                throw new IOException("transform failed", e);
+            }
             return;
         }
         waitableExecutor.execute(new Callable<Void>() {

--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/transform/AtlasMergeJavaResourcesTransform.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tasks/transform/AtlasMergeJavaResourcesTransform.java
@@ -145,7 +145,11 @@ public class AtlasMergeJavaResourcesTransform extends MergeJavaResourcesTransfor
 
     @Override
     public void transform(TransformInvocation invocation) throws IOException {
-
+        // only custom process native lib
+        if (mergedType == QualifiedContent.DefaultContentType.RESOURCES) {
+            super.transform(invocation);
+            return;
+        }
         waitableExecutor.execute(new Callable<Void>() {
             @Override
             public Void call() throws Exception {


### PR DESCRIPTION
暂时修复atlas不能处理主工程的java resources的问题。目前来看atlas设计思想仅对主工程so做了限制，所以在这里判断是merge resource直接调用super的方法处理；如果未来需要对主工程java resource做管控，需要将type传到 AtlasIncrementalFileMergeTransformUtils#toNonIncrementalInput 做进一步判断