### PR TITLE
Inefficient Usage of Collections

### DIFF
--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/android/tools/r8/dex/AtlasVirtualFile.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/android/tools/r8/dex/AtlasVirtualFile.java
@@ -190,7 +190,7 @@ public class AtlasVirtualFile {
             int transactionStartIndex = 0;
             int fileStartIndex = 0;
             String currentPrefix = null;
-            Map<String, Integer> newPackageAssignments = new LinkedHashMap();
+            Map<String, Integer> newPackageAssignments = new HashMap();
             AtlasVirtualFile current = this.cycler.next();
             List<DexProgramClass> nonPackageClasses = new ArrayList();
 

--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/AtlasMainDexHelper.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/AtlasMainDexHelper.java
@@ -37,9 +37,9 @@ public class AtlasMainDexHelper {
 
     private Map<String, Boolean> mainManifestMap = new HashMap<>();
 
-    private Map<String, Boolean> mainNativeSoMap = new LinkedHashMap<>();
+    private Map<String, Boolean> mainNativeSoMap = new HashMap<>();
 
-    private Map<String, Boolean> mainRes = new LinkedHashMap<>();
+    private Map<String, Boolean> mainRes = new HashMap<>();
 
     public File getMainJavaRes() {
         return mainJavaRes;

--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/insant/matcher/MatcherCreator.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/insant/matcher/MatcherCreator.java
@@ -15,7 +15,7 @@ public class MatcherCreator {
 
     static Set<ImplementsMatcher> matchers = new HashSet<>();
 
-    static Map<String, Imatcher> sMatchers = new LinkedHashMap<>();
+    static Map<String, Imatcher> sMatchers = new HashMap<>();
 
     public static Imatcher create(String rule) {
         if (sMatchers.containsKey(rule)) {

--- a/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tools/proguard/AtlasProguardHelper.java
+++ b/atlas-gradle-plugin/atlas-plugin/src/main/java/com/taobao/android/builder/tools/proguard/AtlasProguardHelper.java
@@ -375,24 +375,26 @@ public class AtlasProguardHelper {
     private static void addChildDependency(BundleItem bundleItem, Input input,
                                            Map<BundleInfo, AwbTransform> bundleInfoAwbTransformMap) throws IOException {
 
-        List<String>pkgNames = new ArrayList<>();
+        List<String>pkgNames = new LinkedList<>();
 
         input.getAwbBundles().forEach(awbTransform -> pkgNames.add(awbTransform.getAwbBundle().getPackageName()));
 
         sLogger.info("combine to proguard bundles:"+pkgNames.toString());
 
-        List<AwbTransform> childTransforms = new ArrayList<>();
+        List<AwbTransform> childTransforms = new LinkedList<>();
 
         sLogger.info("combine to proguard bundles:"+pkgNames.toString());
+        
+        Set<String> pkgNameSet = new HashSet<>(pkgNames);
 
         for (BundleItem child : bundleItem.children) {
-            if (!pkgNames.contains(child.bundleInfo.getPkgName())) {
+            if (!pkgNameSet.contains(child.bundleInfo.getPkgName())) {
                 childTransforms.add(bundleInfoAwbTransformMap.get(child.bundleInfo));
             }else {
                 sLogger.error(child.bundleInfo.getPkgName() +" in proguard bundles so discard from "+ bundleItem.bundleInfo.getPkgName()+"libraries...");
             }
             for (BundleInfo sub : child.circles) {
-                if (!pkgNames.contains(sub.getPkgName())) {
+                if (!pkgNameSet.contains(sub.getPkgName())) {
                     childTransforms.add(bundleInfoAwbTransformMap.get(sub));
                 }else {
                     sLogger.error(sub.getPkgName() +" in proguard bundles so discard from "+ bundleItem.bundleInfo.getPkgName()+" libraries...");

--- a/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/repatch/ClassReIClassDef.java
+++ b/atlas-gradle-plugin/dexpatch/src/main/java/com/taobao/android/repatch/ClassReIClassDef.java
@@ -470,6 +470,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
 
     @Override
     protected Annotation reAnnotation(Annotation annotation) {
+        Set<String> basicValueSet = new HashSet<>(basicValue);
         String type = annotation.getType();
         boolean isArray = false;
         if (type.startsWith("[")) {
@@ -491,7 +492,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                         if (value.startsWith("[")) {
                             isArray1 = true;
                         }
-                        if (basicValue.contains(value)) {
+                        if (basicValueSet.contains(value)) {
                             newValue = value;
                         } else if (value.startsWith("Ljava/util/") || value.startsWith("Ljava/lang/") || !value.startsWith("L")) {
                             newValue = value;
@@ -512,7 +513,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                         if (value.startsWith("[")) {
                             isArray2 = true;
                         }
-                        if (basicValue.contains(value)) {
+                        if (basicValueSet.contains(value)) {
                             newValueSub = value;
                         } else if (value.startsWith("Ljava/util/") || !value.endsWith(";")) {
                             newValueSub = value;
@@ -537,7 +538,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                 if (value.startsWith("[")) {
                     isArray = true;
                 }
-                if (basicValue.contains(value)) {
+                if (basicValueSet.contains(value)) {
                     newValue = value;
                 } else if (value.startsWith("Ljava/util/") || value.startsWith("Ljava/lang/") || !value.startsWith("L")) {
                     newValue = value;
@@ -559,7 +560,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                 if (value.startsWith("[")) {
                     isArray2 = true;
                 }
-                if (basicValue.contains(value)) {
+                if (basicValueSet.contains(value)) {
                     newValue = value;
                 } else if (value.startsWith("Ljava/util/") || !value.endsWith(";")) {
                     newValue = value;
@@ -665,6 +666,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
             String newType = DefineUtils.getDefineClassName(classProcessor.classProcess(DefineUtils.getDalvikClassName(type)).className, isArray);
             Set<? extends AnnotationElement> sets = annotation.getElements();
             Set<ImmutableAnnotationElement> newAnnotationElement = new HashSet<ImmutableAnnotationElement>();
+            Set<String> basicValueSet = new HashSet<>(basicValue);
             for (AnnotationElement annotationElement : sets) {
                 String name = annotationElement.getName();
                 EncodedValue encodedValue = annotationElement.getValue();
@@ -678,7 +680,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                             if (value.startsWith("[")) {
                                 isArray1 = true;
                             }
-                            if (basicValue.contains(value)) {
+                            if (basicValueSet.contains(value)) {
                                 newValue = value;
                             } else if (value.startsWith("Ljava/util/") || !value.endsWith(";") || value.startsWith("Ljava/lang/")||!value.startsWith("L")) {
                                 newValue = value;
@@ -694,7 +696,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                             if (value.startsWith("[")) {
                                 isArray2 = true;
                             }
-                            if (basicValue.contains(value)) {
+                            if (basicValueSet.contains(value)) {
                                 newValueSub = value;
                             } else if (value.startsWith("Ljava/util/") || value.startsWith("Ljava/lang/") || !value.endsWith(";")) {
                                 newValueSub = value;
@@ -719,7 +721,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                         isArray3 = true;
                     }
                     String newValue = null;
-                    if (basicValue.contains(value)) {
+                    if (basicValueSet.contains(value)) {
                         newValue = value;
                     } else if (value.startsWith("Ljava/util/") || value.startsWith("Ljava/lang/") || !value.endsWith(";")) {
                         newValue = value;
@@ -774,7 +776,7 @@ public abstract class ClassReIClassDef extends AbIClassDef {
                     if (value.startsWith("[")) {
                         isArray2 = true;
                     }
-                    if (basicValue.contains(value)) {
+                    if (basicValueSet.contains(value)) {
                         newValueSub = value;
                     } else if (value.startsWith("Ljava/util/") || value.startsWith("Ljava/lang/") || !value.endsWith(";")) {
                         newValueSub = value;

--- a/atlas-update/src/main/java/com/taobao/atlas/dexmerge/dx/merge/DexTransform.java
+++ b/atlas-update/src/main/java/com/taobao/atlas/dexmerge/dx/merge/DexTransform.java
@@ -232,7 +232,7 @@ public final class DexTransform {
         return this;
     }
 
-    public DexTransform markClassDef(Dex baseDex,List<String>classNames) {
+    public DexTransform markClassDef(Dex baseDex,Set<String>classNames) {
         for (ClassDef classDef:dex.classDefs()) {
             int typeId = classDef.getTypeIndex();
             String value = dex.typeNames().get(typeId);


### PR DESCRIPTION
Hi,

We find that there are several inefficient usages of Java Collections:

1. The contains method is invoked upon a list object. We recommend replacing it with a HashSet.
2. There is no iteration occurring upon a LinkedHashMap, thus the insertion order does not matter. We recommend replacing it with a HashMap.
3. ArrayList is inserted before an iteration, while multiple memory reallocation might occur when the size of the list exceeds its capacity. We recommend replacing it with a LinkedList.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto