### PR TITLE
[atlas-update] Avoid Zip Slip Vulnerability

### DIFF
--- a/atlas-update/src/main/java/com/taobao/atlas/update/util/ZipUtils.java
+++ b/atlas-update/src/main/java/com/taobao/atlas/update/util/ZipUtils.java
@@ -36,10 +36,18 @@ public class ZipUtils {
                 dirName = dirName.substring(0, dirName.length() - 1);
                 File f = new File(outFile.getPath() + File.separator + dirName);
                 f.mkdirs();
+                if (!f.getCanonicalPath().startsWith(outputDirectory)) {
+                    System.out.println("Zip Slip exploit detected. Skipping entry " + dirName);
+                    continue;
+                }
             } else {
                 String strFilePath = outFile.getPath() + File.separator
                         + zipEntry.getName();
                 File f = new File(strFilePath);
+                if (!f.getCanonicalPath().startsWith(outputDirectory)) {
+                    System.out.println("Zip Slip exploit detected. Skipping entry " + zipEntry.getName());
+                    continue;
+                }
 
                 // 判断文件不存在的话，就创建该文件所在文件夹的目录
                 if (!f.exists()) {


### PR DESCRIPTION
`atlas` is vulnerable to Zip Slip attacks using [unzip](https://github.com/alibaba/atlas/blob/c20c5b83f67b9a14fb597d59a287ec7a3e5bdbac/atlas-update/src/main/java/com/taobao/atlas/update/util/ZipUtils.java#L20). Reported in [huntr](https://www.huntr.dev/bounties/7f0f0f66-34db-4a83-a248-6e20c0f5d551/).

```
ZipUtils.unzip("C:\evil.zip", "D:\test\test\test");      //input evil.zip contains ../../evil.exe which will be extracted in D:\test
```